### PR TITLE
docs: correct `package_json.manager.add` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ executing:
 package_json = PackageJson.new
 
 # adds eslint, eslint-plugin-prettier, and prettier as development dependencies
-package_json.manager.add(%w[eslint prettier], :dev)
+package_json.manager.add(%w[eslint prettier], type: :dev)
 
 # adds the "lint" and "format" scripts, preserving any existing scripts
 package_json.merge! do |pj|


### PR DESCRIPTION
A very minor fix in docs to reduce confusion.

If you think we won't need any other options to pass to such methods, maybe better to use `type = :production`. This way, one doesn't need to mention `type` and can directly use `:dev` for example.

But if you want to keep it open for future use cases, maybe it is better to use `options = { type: :production }`.

This is just to explore the best possible approach. It is beyond the scope of this PR.