### PR TITLE
fix: detect yarn classic only with version 1

### DIFF
--- a/lib/package_json.rb
+++ b/lib/package_json.rb
@@ -87,7 +87,11 @@ class PackageJson
   def determin_yarn_version(version)
     raise Error, "a major version must be present for Yarn" if version.nil? || version.empty?
 
-    return :yarn_classic if version.match?(/^[~^]?1(\..{,20})?$/)
+    # Regex for matching version 1 with ~ or ^ prefix and optionally minor and path version
+    # This regext doesn't check the validity of the version format!
+    version_1_regex = /^[~^]?1(\..{,20})?$/
+
+    return :yarn_classic if version.match? version_1_regex
 
     :yarn_berry
   end

--- a/lib/package_json.rb
+++ b/lib/package_json.rb
@@ -87,7 +87,7 @@ class PackageJson
   def determin_yarn_version(version)
     raise Error, "a major version must be present for Yarn" if version.nil? || version.empty?
 
-    return :yarn_classic if version.start_with? "1."
+    return :yarn_classic if version.match?(/^[~^]?1(\..+)*$/)
 
     :yarn_berry
   end

--- a/lib/package_json.rb
+++ b/lib/package_json.rb
@@ -87,11 +87,9 @@ class PackageJson
   def determin_yarn_version(version)
     raise Error, "a major version must be present for Yarn" if version.nil? || version.empty?
 
-    # Regex for matching version 1 with ~ or ^ prefix and optionally minor and path version
-    # This regext doesn't check the validity of the version format!
-    version_1_regex = /^[~^]?1(\.|$)/
-
-    return :yarn_classic if version.match? version_1_regex
+    # check to see if we're meant to be using Yarn v1 based on the versions major component,
+    # and accounting for the presents of version constraints like ^, ~, and =
+    return :yarn_classic if version.match? /^[^~=]?1(\.|$)/
 
     :yarn_berry
   end

--- a/lib/package_json.rb
+++ b/lib/package_json.rb
@@ -79,14 +79,17 @@ class PackageJson
 
     name, version = package_manager.split("@")
 
-    if name == "yarn"
-      raise Error, "a major version must be present for Yarn" if version.nil? || version.empty?
-      return :yarn_classic if version.start_with?("1")
-
-      return :yarn_berry
-    end
+    return determin_yarn_version(version) if name == "yarn"
 
     name.to_sym
+  end
+
+  def determin_yarn_version(version)
+    raise Error, "a major version must be present for Yarn" if version.nil? || version.empty?
+
+    return :yarn_classic if version.start_with? "1."
+
+    :yarn_berry
   end
 
   def new_package_manager(package_manager_name)

--- a/lib/package_json.rb
+++ b/lib/package_json.rb
@@ -88,7 +88,7 @@ class PackageJson
     raise Error, "a major version must be present for Yarn" if version.nil? || version.empty?
 
     # check to see if we're meant to be using Yarn v1 based on the versions major component,
-    # and accounting for the presents of version constraints like ^, ~, and =
+    # and accounting for the presence of version constraints like ^, ~, and =
     return :yarn_classic if version.match?(/^[~=^]?1(\.|$)/)
 
     :yarn_berry

--- a/lib/package_json.rb
+++ b/lib/package_json.rb
@@ -89,7 +89,7 @@ class PackageJson
 
     # Regex for matching version 1 with ~ or ^ prefix and optionally minor and path version
     # This regext doesn't check the validity of the version format!
-    version_1_regex = /^[~^]?1(\..{,20})?$/
+    version_1_regex = /^[~^]?1(\.|$)/
 
     return :yarn_classic if version.match? version_1_regex
 

--- a/lib/package_json.rb
+++ b/lib/package_json.rb
@@ -89,7 +89,7 @@ class PackageJson
 
     # check to see if we're meant to be using Yarn v1 based on the versions major component,
     # and accounting for the presents of version constraints like ^, ~, and =
-    return :yarn_classic if version.match? /^[^~=]?1(\.|$)/
+    return :yarn_classic if version.match?(/^[~=^]?1(\.|$)/)
 
     :yarn_berry
   end

--- a/lib/package_json.rb
+++ b/lib/package_json.rb
@@ -87,7 +87,7 @@ class PackageJson
   def determin_yarn_version(version)
     raise Error, "a major version must be present for Yarn" if version.nil? || version.empty?
 
-    return :yarn_classic if version.match?(/^[~^]?1(\..+)*$/)
+    return :yarn_classic if version.match?(/^[~^]?1(\..{,20})?$/)
 
     :yarn_berry
   end

--- a/spec/package_json_spec.rb
+++ b/spec/package_json_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe PackageJson do
         end
       end
 
-      it "only returns yarn berry if the major version is 11" do
+      it "returns yarn berry if the major version is 11" do
         with_package_json_file({ "version" => "1.0.0", "packageManager" => "yarn@11.2.3" }) do
           package_json = described_class.read
 
@@ -521,6 +521,53 @@ RSpec.describe PackageJson do
           expect_package_json_with_content({ "packageManager" => start_with("npm@9.") })
         end
       end
+    end
+  end
+
+  describe "the private method #determin_yarn_version" do
+    let(:package_json) { described_class.new }
+
+    it "raises error if no version is given" do
+      expect { package_json.send(:determin_yarn_version, nil) }.to raise_error("a major version must be present for Yarn")
+    end
+
+    it "raises error if blank version is given" do
+      expect { package_json.send(:determin_yarn_version, "") }.to raise_error("a major version must be present for Yarn")
+    end
+
+    it "returns yarn classic for version 1" do
+      determined_version = package_json.send(:determin_yarn_version, "1")
+      expect(determined_version).to be :yarn_classic
+    end
+
+    it "returns yarn classic for version 1.2" do
+      determined_version = package_json.send(:determin_yarn_version, "1.2")
+      expect(determined_version).to be :yarn_classic
+    end
+
+    it "returns yarn classic for version ^1.x" do
+      determined_version = package_json.send(:determin_yarn_version, "^1.x")
+      expect(determined_version).to be :yarn_classic
+    end
+
+    it "returns yarn classic for version ~1.2" do
+      determined_version = package_json.send(:determin_yarn_version, "~1.2")
+      expect(determined_version).to be :yarn_classic
+    end
+
+    it "returns yarn berry for version 11" do
+      determined_version = package_json.send(:determin_yarn_version, "11")
+      expect(determined_version).to be :yarn_berry
+    end
+
+    it "returns yarn berry for version ~11.x" do
+      determined_version = package_json.send(:determin_yarn_version, "~11.x")
+      expect(determined_version).to be :yarn_berry
+    end
+
+    it "returns yarn berry for version 2" do
+      determined_version = package_json.send(:determin_yarn_version, "2")
+      expect(determined_version).to be :yarn_berry
     end
   end
 end

--- a/spec/package_json_spec.rb
+++ b/spec/package_json_spec.rb
@@ -87,6 +87,14 @@ RSpec.describe PackageJson do
         end
       end
 
+      it "supports yarn classic with exact version" do
+        with_package_json_file({ "version" => "1.0.0", "packageManager" => "yarn@=1.2" }) do
+          package_json = described_class.read
+
+          expect(package_json.manager).to be_a PackageJson::Managers::YarnClassicLike
+        end
+      end
+
       it "doesn't return yarn classic if the major version is 11" do
         with_package_json_file({ "version" => "1.0.0", "packageManager" => "yarn@11.2.3" }) do
           package_json = described_class.read

--- a/spec/package_json_spec.rb
+++ b/spec/package_json_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe PackageJson do
         end
       end
 
-      it "doesn't return yarn classic if the major version is 11" do
+      it "does not return yarn classic if the major version is 11" do
         with_package_json_file({ "version" => "1.0.0", "packageManager" => "yarn@11.2.3" }) do
           package_json = described_class.read
 

--- a/spec/package_json_spec.rb
+++ b/spec/package_json_spec.rb
@@ -528,11 +528,15 @@ RSpec.describe PackageJson do
     let(:package_json) { described_class.new }
 
     it "raises error if no version is given" do
-      expect { package_json.send(:determin_yarn_version, nil) }.to raise_error("a major version must be present for Yarn")
+      expect do
+        package_json.send(:determin_yarn_version, nil)
+      end.to raise_error("a major version must be present for Yarn")
     end
 
     it "raises error if blank version is given" do
-      expect { package_json.send(:determin_yarn_version, "") }.to raise_error("a major version must be present for Yarn")
+      expect do
+        package_json.send(:determin_yarn_version, "")
+      end.to raise_error("a major version must be present for Yarn")
     end
 
     it "returns yarn classic for version 1" do

--- a/spec/package_json_spec.rb
+++ b/spec/package_json_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe PackageJson do
         end
       end
 
-      it "supports yarn classic" do
+      it "supports yarn classic with version 1.2.3" do
         with_package_json_file({ "version" => "1.0.0", "packageManager" => "yarn@1.2.3" }) do
           package_json = described_class.read
 
@@ -63,7 +63,39 @@ RSpec.describe PackageJson do
         end
       end
 
-      it "supports yarn berry" do
+      it "supports yarn classic with version 1" do
+        with_package_json_file({ "version" => "1.0.0", "packageManager" => "yarn@1" }) do
+          package_json = described_class.read
+
+          expect(package_json.manager).to be_a PackageJson::Managers::YarnClassicLike
+        end
+      end
+
+      it "supports yarn classic with version ^1.2" do
+        with_package_json_file({ "version" => "1.0.0", "packageManager" => "yarn@^1.2" }) do
+          package_json = described_class.read
+
+          expect(package_json.manager).to be_a PackageJson::Managers::YarnClassicLike
+        end
+      end
+
+      it "supports yarn classic with version ~1.2" do
+        with_package_json_file({ "version" => "1.0.0", "packageManager" => "yarn@~1.2" }) do
+          package_json = described_class.read
+
+          expect(package_json.manager).to be_a PackageJson::Managers::YarnClassicLike
+        end
+      end
+
+      it "doesn't return yarn classic if the major version is 11" do
+        with_package_json_file({ "version" => "1.0.0", "packageManager" => "yarn@11.2.3" }) do
+          package_json = described_class.read
+
+          expect(package_json.manager).not_to be_a PackageJson::Managers::YarnClassicLike
+        end
+      end
+
+      it "supports yarn berry with version 2.3.2" do
         with_package_json_file({ "version" => "1.0.0", "packageManager" => "yarn@2.3.2" }) do
           package_json = described_class.read
 
@@ -71,8 +103,8 @@ RSpec.describe PackageJson do
         end
       end
 
-      it "returns yarn berry if the major version is 11" do
-        with_package_json_file({ "version" => "1.0.0", "packageManager" => "yarn@11.2.3" }) do
+      it "returns yarn berry if the major version is ~11.2.3" do
+        with_package_json_file({ "version" => "1.0.0", "packageManager" => "yarn@~11.2.3" }) do
           package_json = described_class.read
 
           expect(package_json.manager).to be_a PackageJson::Managers::YarnBerryLike
@@ -521,57 +553,6 @@ RSpec.describe PackageJson do
           expect_package_json_with_content({ "packageManager" => start_with("npm@9.") })
         end
       end
-    end
-  end
-
-  describe "the private method #determin_yarn_version" do
-    let(:package_json) { described_class.new }
-
-    it "raises error if no version is given" do
-      expect do
-        package_json.send(:determin_yarn_version, nil)
-      end.to raise_error("a major version must be present for Yarn")
-    end
-
-    it "raises error if blank version is given" do
-      expect do
-        package_json.send(:determin_yarn_version, "")
-      end.to raise_error("a major version must be present for Yarn")
-    end
-
-    it "returns yarn classic for version 1" do
-      determined_version = package_json.send(:determin_yarn_version, "1")
-      expect(determined_version).to be :yarn_classic
-    end
-
-    it "returns yarn classic for version 1.2" do
-      determined_version = package_json.send(:determin_yarn_version, "1.2")
-      expect(determined_version).to be :yarn_classic
-    end
-
-    it "returns yarn classic for version ^1.x" do
-      determined_version = package_json.send(:determin_yarn_version, "^1.x")
-      expect(determined_version).to be :yarn_classic
-    end
-
-    it "returns yarn classic for version ~1.2" do
-      determined_version = package_json.send(:determin_yarn_version, "~1.2")
-      expect(determined_version).to be :yarn_classic
-    end
-
-    it "returns yarn berry for version 11" do
-      determined_version = package_json.send(:determin_yarn_version, "11")
-      expect(determined_version).to be :yarn_berry
-    end
-
-    it "returns yarn berry for version ~11.x" do
-      determined_version = package_json.send(:determin_yarn_version, "~11.x")
-      expect(determined_version).to be :yarn_berry
-    end
-
-    it "returns yarn berry for version 2" do
-      determined_version = package_json.send(:determin_yarn_version, "2")
-      expect(determined_version).to be :yarn_berry
     end
   end
 end

--- a/spec/package_json_spec.rb
+++ b/spec/package_json_spec.rb
@@ -103,14 +103,6 @@ RSpec.describe PackageJson do
         end
       end
 
-      it "returns yarn berry if the major version is ~11.2.3" do
-        with_package_json_file({ "version" => "1.0.0", "packageManager" => "yarn@~11.2.3" }) do
-          package_json = described_class.read
-
-          expect(package_json.manager).to be_a PackageJson::Managers::YarnBerryLike
-        end
-      end
-
       it "does not change the packageManager property" do
         with_package_json_file({ "version" => "1.0.0", "packageManager" => "pnpm" }) do
           described_class.read(Dir.pwd, fallback_manager: :yarn_classic)

--- a/spec/package_json_spec.rb
+++ b/spec/package_json_spec.rb
@@ -71,6 +71,14 @@ RSpec.describe PackageJson do
         end
       end
 
+      it "only returns yarn berry if the major version is 11" do
+        with_package_json_file({ "version" => "1.0.0", "packageManager" => "yarn@11.2.3" }) do
+          package_json = described_class.read
+
+          expect(package_json.manager).to be_a PackageJson::Managers::YarnBerryLike
+        end
+      end
+
       it "does not change the packageManager property" do
         with_package_json_file({ "version" => "1.0.0", "packageManager" => "pnpm" }) do
           described_class.read(Dir.pwd, fallback_manager: :yarn_classic)

--- a/spec/package_json_spec.rb
+++ b/spec/package_json_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe PackageJson do
         end
       end
 
-      it "supports yarn classic with version 1" do
+      it "supports yarn classic with just a major version" do
         with_package_json_file({ "version" => "1.0.0", "packageManager" => "yarn@1" }) do
           package_json = described_class.read
 
@@ -71,7 +71,7 @@ RSpec.describe PackageJson do
         end
       end
 
-      it "supports yarn classic with version ^1.2" do
+      it "supports yarn classic with a caret constraint" do
         with_package_json_file({ "version" => "1.0.0", "packageManager" => "yarn@^1.2" }) do
           package_json = described_class.read
 
@@ -79,7 +79,7 @@ RSpec.describe PackageJson do
         end
       end
 
-      it "supports yarn classic with version ~1.2" do
+      it "supports yarn classic with tilde constraint" do
         with_package_json_file({ "version" => "1.0.0", "packageManager" => "yarn@~1.2" }) do
           package_json = described_class.read
 


### PR DESCRIPTION
Though not very sensitive, the current logic assumes a version starting with `1` is necessarily `1.x`. This issue is fixed (assuming we get a valid `x.y.z` format for the version in `package.json`.