### PR TITLE
test: enable pending example

### DIFF
--- a/spec/package_json/managers/bun_like_spec.rb
+++ b/spec/package_json/managers/bun_like_spec.rb
@@ -34,8 +34,6 @@ RSpec.describe PackageJson::Managers::BunLike do
 
     it "supports frozen" do
       with_package_json_file do
-        pending "bun currently does not support an empty lockfile - https://github.com/oven-sh/bun/issues/5162"
-
         result = manager.install(frozen: true)
 
         expect_manager_to_be_invoked_with("install --frozen-lockfile")

--- a/spec/package_json/managers/bun_like_spec.rb
+++ b/spec/package_json/managers/bun_like_spec.rb
@@ -14,16 +14,12 @@ RSpec.describe PackageJson::Managers::BunLike do
     before { allow_open3_to_receive_capture3_for_package_manager }
 
     it "returns the version" do
-      skip_on_windows
-
       expect(manager.version).to start_with("1.")
     end
   end
 
   describe "#install" do
     it "runs and returns true" do
-      skip_on_windows
-
       with_package_json_file do
         result = manager.install
 
@@ -53,8 +49,6 @@ RSpec.describe PackageJson::Managers::BunLike do
 
     context "when the current working directory is changed" do
       it "interacts with the right package.json" do
-        skip_on_windows
-
         with_package_json_file do
           manager # initialize the package.json in the current directory
 
@@ -70,8 +64,6 @@ RSpec.describe PackageJson::Managers::BunLike do
 
   describe "#install!" do
     it "runs and returns nil" do
-      skip_on_windows
-
       with_package_json_file do
         expect(manager.install!).to be_nil
       end
@@ -102,8 +94,6 @@ RSpec.describe PackageJson::Managers::BunLike do
 
   describe "#add" do
     it "adds dependencies as production by default" do
-      skip_on_windows
-
       with_package_json_file do
         result = manager.add(["example"])
 
@@ -118,8 +108,6 @@ RSpec.describe PackageJson::Managers::BunLike do
     end
 
     it "supports adding production dependencies" do
-      skip_on_windows
-
       with_package_json_file do
         result = manager.add(["example"], type: :production)
 
@@ -134,8 +122,6 @@ RSpec.describe PackageJson::Managers::BunLike do
     end
 
     it "supports adding dev dependencies" do
-      skip_on_windows
-
       with_package_json_file do
         result = manager.add(["example"], type: :dev)
 
@@ -150,8 +136,6 @@ RSpec.describe PackageJson::Managers::BunLike do
     end
 
     it "supports adding optional dependencies" do
-      skip_on_windows
-
       with_package_json_file do
         result = manager.add(["example"], type: :optional)
 
@@ -179,8 +163,6 @@ RSpec.describe PackageJson::Managers::BunLike do
 
     context "when the current working directory is changed" do
       it "interacts with the right package.json" do
-        skip_on_windows
-
         manager # initialize the package.json in the current directory
 
         within_subdirectory("subdir") do
@@ -194,8 +176,6 @@ RSpec.describe PackageJson::Managers::BunLike do
 
   describe "#add!" do
     it "returns nil" do
-      skip_on_windows
-
       with_package_json_file do
         expect(manager.add!(["example"])).to be_nil
       end
@@ -210,8 +190,6 @@ RSpec.describe PackageJson::Managers::BunLike do
 
   describe "#remove" do
     it "removes the package and returns true" do
-      skip_on_windows
-
       with_package_json_file({ "dependencies" => { "example" => "^0.0.0", "example2" => "^0.0.0" } }) do
         result = manager.remove(["example"])
 
@@ -242,8 +220,6 @@ RSpec.describe PackageJson::Managers::BunLike do
 
     context "when the current working directory is changed" do
       it "interacts with the right package.json" do
-        skip_on_windows
-
         with_package_json_file({ "dependencies" => { "example" => "^0.0.0", "example2" => "^0.0.0" } }) do
           manager # initialize the package.json in the current directory
 
@@ -265,8 +241,6 @@ RSpec.describe PackageJson::Managers::BunLike do
 
   describe "#remove!" do
     it "returns nil" do
-      skip_on_windows
-
       with_package_json_file({ "dependencies" => { "example" => "^0.0.0", "example2" => "^0.0.0" } }) do
         result = manager.remove!(["example"])
 
@@ -303,8 +277,6 @@ RSpec.describe PackageJson::Managers::BunLike do
     end
 
     it "runs the script" do
-      skip_on_windows
-
       with_package_json_file({ "scripts" => { "rspec-test-helper" => "ruby helper.rb" } }) do
         result = manager.run("rspec-test-helper")
 
@@ -315,8 +287,6 @@ RSpec.describe PackageJson::Managers::BunLike do
     end
 
     it "passes args correctly" do
-      skip_on_windows
-
       with_package_json_file({ "scripts" => { "rspec-test-helper" => "ruby helper.rb" } }) do
         result = manager.run("rspec-test-helper", ["--silent", "--flag", "value"])
 
@@ -348,8 +318,6 @@ RSpec.describe PackageJson::Managers::BunLike do
     end
 
     it "supports the silent option" do
-      skip_on_windows
-
       with_package_json_file({ "scripts" => { "rspec-test-helper" => "ruby helper.rb" } }) do
         result = manager.run("rspec-test-helper", silent: true)
 
@@ -360,8 +328,6 @@ RSpec.describe PackageJson::Managers::BunLike do
     end
 
     it "supports the silent option with args" do
-      skip_on_windows
-
       with_package_json_file({ "scripts" => { "rspec-test-helper" => "ruby helper.rb" } }) do
         result = manager.run("rspec-test-helper", ["--silent", "value", "--flag"], silent: true)
 
@@ -373,8 +339,6 @@ RSpec.describe PackageJson::Managers::BunLike do
 
     context "when the current working directory is changed" do
       it "interacts with the right package.json" do
-        skip_on_windows
-
         with_package_json_file({ "scripts" => { "rspec-test-helper" => "ruby helper.rb" } }) do
           manager # initialize the package.json in the current directory
 
@@ -397,8 +361,6 @@ RSpec.describe PackageJson::Managers::BunLike do
     end
 
     it "returns nil" do
-      skip_on_windows
-
       with_package_json_file({ "scripts" => { "rspec-test-helper" => "ruby helper.rb" } }) do
         result = manager.run!("rspec-test-helper")
 

--- a/spec/package_json_spec.rb
+++ b/spec/package_json_spec.rb
@@ -215,13 +215,9 @@ RSpec.describe PackageJson do
       end
 
       it "sets packageManager correctly when the package manager is bun" do
-        skip_on_windows(pend: true)
-
         described_class.new(fallback_manager: :bun)
 
-        # :nocov:
         expect_package_json_with_content({ "packageManager" => start_with("bun@1.") })
-        # :nocov:
       end
 
       it "raises an error if the fallback manager is not supported" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,7 +22,7 @@ require "./spec/support/expect_helpers"
 require "./spec/support/status_struct"
 require "./spec/support/temp_helpers"
 
-def skip_on_windows(pend: false)
+def skip_on_windows(pend: true)
   # :nocov:
   return unless Gem.win_platform?
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,17 +22,6 @@ require "./spec/support/expect_helpers"
 require "./spec/support/status_struct"
 require "./spec/support/temp_helpers"
 
-def skip_on_windows(pend: true)
-  # :nocov:
-  return unless Gem.win_platform?
-
-  skip "Not supported on Windows" unless pend
-
-  pending "Not supported on Windows"
-
-  # :nocov:
-end
-
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
[It seems like this is now passing](https://github.com/oven-sh/bun/issues/5162#issuecomment-2041890097) - it still errors if the lockfile exists but is empty, but that's not relevant for this test.

Bun now also supports Windows, so those tests can be enabled