### PR TITLE
chore: add `arm64-darwin-22` platform to lockfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
   x64-mingw-ucrt
   x64-mingw32
   x86_64-darwin-19


### PR DESCRIPTION
I guess this got released today